### PR TITLE
Configure GitHub copilot for inline completions in Neovim

### DIFF
--- a/planet/home-manager/neovim/default.nix
+++ b/planet/home-manager/neovim/default.nix
@@ -74,6 +74,11 @@
         );
       };
 
+      # Persist GitHub copilot credentials.
+      planet.persistence = {
+        directories = [ ".config/github-copilot" ];
+      };
+
       programs.neovim = {
         inherit (cfg) package;
         enable = true;
@@ -132,6 +137,7 @@
             vue-language-server
             astro-language-server
             zls
+            copilot-language-server
             (texlive.combine {
               inherit (texlive) scheme-minimal latexindent;
             })

--- a/planet/home-manager/neovim/lua/plugins/cmp.lua
+++ b/planet/home-manager/neovim/lua/plugins/cmp.lua
@@ -20,6 +20,9 @@ function M.setup()
          -- completion = cmp.config.window.bordered(),
          -- documentation = cmp.config.window.bordered(),
       },
+      completion = {
+         autocomplete = false,
+      },
       mapping = cmp.mapping.preset.insert({
          ["<Tab>"] = cmp.mapping(function(fallback)
             local has_words_before = function()

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/astro-ls.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/astro-ls.lua
@@ -1,9 +1,8 @@
 local M = {}
 
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    vim.lsp.enable("astro")
    vim.lsp.config("astro", {
-      on_attach = on_attach,
       capabilities = capabilities,
    })
 end

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/clangd.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/clangd.lua
@@ -1,10 +1,9 @@
 local M = {}
 
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    capabilities.offsetEncoding = { "utf-16" }
    vim.lsp.enable("clangd")
    vim.lsp.config("clangd", {
-      on_attach = on_attach,
       capabilities = capabilities,
    })
 end

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/common.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/common.lua
@@ -106,6 +106,24 @@ local function setup_mappings(bufnr)
          end,
       })
    end, { silent = true, buffer = bufnr, desc = "Format" })
+
+   vim.keymap.set("n", "<leader>li", function()
+      local enabled = vim.lsp.inline_completion.is_enabled({ bufnr = bufnr })
+      vim.lsp.inline_completion.enable(not enabled, { bufnr = bufnr })
+      vim.notify("Inline completion " .. (enabled and "disabled" or "enabled"), vim.log.levels.INFO)
+   end, { desc = "Toggle inline completion", buffer = bufnr })
+
+   vim.keymap.set({ "n", "i" }, "<C-\\>", vim.lsp.inline_completion.get, {
+      desc = "Apply inline completion",
+      buffer = bufnr,
+   })
+
+   vim.keymap.set(
+      { "n", "i" },
+      "<C-S-\\>",
+      vim.lsp.inline_completion.select,
+      { desc = "Switch inline completion", buffer = bufnr }
+   )
 end
 
 -- nvim-navic
@@ -123,6 +141,12 @@ end
 function M.on_attach(client, bufnr)
    setup_mappings(bufnr)
    setup_navic(client, bufnr)
+
+   -- Enable inline completion by default if the client supports it.
+   -- Can be toggled with `<leader>li`.
+   if client:supports_method(vim.lsp.protocol.Methods.textDocument_inlineCompletion, bufnr) then
+      vim.lsp.inline_completion.enable(true, { bufnr = bufnr })
+   end
 end
 
 function M.capabilities()

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/copilot-language-server.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/copilot-language-server.lua
@@ -1,0 +1,15 @@
+local M = {}
+
+function M.setup(capabilities)
+   vim.lsp.enable("copilot")
+   vim.lsp.config("copilot", {
+      capabilities = capabilities,
+      settings = {
+         telemetry = {
+            telemtryLevel = "off",
+         },
+      },
+   })
+end
+
+return M

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/efm.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/efm.lua
@@ -48,7 +48,7 @@ local htmlhint = {
    lintFormats = { "%f:%l:%c: %m" },
 }
 
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    local languages = {
       lua = { stylua },
       fennel = { fnlfmt },
@@ -98,7 +98,6 @@ function M.setup(on_attach, capabilities)
 
    vim.lsp.enable("efm")
    vim.lsp.config("efm", {
-      on_attach = on_attach,
       capabilities = capabilities,
       filetypes = vim.tbl_keys(languages),
       init_options = {

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/gopls.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/gopls.lua
@@ -1,9 +1,8 @@
 local M = {}
 
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    vim.lsp.enable("gopls")
    vim.lsp.config("gopls", {
-      on_attach = on_attach,
       capabilities = capabilities,
    })
 end

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/hls.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/hls.lua
@@ -1,9 +1,8 @@
 local M = {}
 
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    vim.lsp.enable("hls")
    vim.lsp.config("hls", {
-      on_attach = on_attach,
       capabilities = capabilities,
       settings = {
          haskell = {

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/init.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/init.lua
@@ -43,6 +43,7 @@ local servers = {
    "vtsls",
    "astro-ls",
    "zls",
+   "copilot-language-server",
 }
 
 local function setup_servers()

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/init.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/init.lua
@@ -48,7 +48,7 @@ local servers = {
 local function setup_servers()
    for _, server in ipairs(servers) do
       local capabilities = common.capabilities()
-      require("plugins.lspconfig." .. server).setup(common.on_attach, capabilities)
+      require("plugins.lspconfig." .. server).setup(capabilities)
    end
 end
 
@@ -64,6 +64,17 @@ function M.setup()
             })
          end,
       },
+   })
+
+   local lsp_cmds = vim.api.nvim_create_augroup("lsp_cmds", { clear = true })
+   vim.api.nvim_create_autocmd("LspAttach", {
+      group = lsp_cmds,
+      desc = "Global LSP attach callback",
+      callback = function(event)
+         local bufnr = event.buf
+         local client = vim.lsp.get_client_by_id(event.data.client_id)
+         common.on_attach(client, bufnr)
+      end,
    })
 
    setup_mappings()

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/ltex.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/ltex.lua
@@ -1,9 +1,8 @@
 local M = {}
 
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    vim.lsp.enable("ltex")
    vim.lsp.config("ltex", {
-      on_attach = on_attach,
       capabilities = capabilities,
       settings = {
          ltex = {

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/lua-ls.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/lua-ls.lua
@@ -1,12 +1,11 @@
 local M = {}
 
 local lazydev = require("lazydev")
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    lazydev.setup()
 
    vim.lsp.enable("lua_ls")
    vim.lsp.config("lua_ls", {
-      on_attach = on_attach,
       capabilities = capabilities,
       settings = {
          Lua = {

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/nil-ls.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/nil-ls.lua
@@ -1,9 +1,8 @@
 local M = {}
 
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    vim.lsp.enable("nil_ls")
    vim.lsp.config("nil_ls", {
-      on_attach = on_attach,
       capabilities = capabilities,
       settings = {
          ["nil"] = {

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/pyrefly.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/pyrefly.lua
@@ -1,9 +1,8 @@
 local M = {}
 
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    vim.lsp.enable("pyrefly")
    vim.lsp.config("pyrefly", {
-      on_attach = on_attach,
       capabilities = capabilities,
    })
 end

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/rust-analyzer.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/rust-analyzer.lua
@@ -1,9 +1,8 @@
 local M = {}
 
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    vim.lsp.enable("rust_analyzer")
    vim.lsp.config("rust_analyzer", {
-      on_attach = on_attach,
       capabilities = capabilities,
       settings = {
          ["rust-analyzer"] = {

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/svelte-language-server.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/svelte-language-server.lua
@@ -1,9 +1,8 @@
 local M = {}
 
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    vim.lsp.enable("svelte")
    vim.lsp.config("svelte", {
-      on_attach = on_attach,
       capabilities = capabilities,
    })
 end

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/tinymist.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/tinymist.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    -- Neovim does not recognize Typst files by default,
    -- so the filetype needs to be manually registered.
    vim.filetype.add({
@@ -11,7 +11,6 @@ function M.setup(on_attach, capabilities)
 
    vim.lsp.enable("tinymist")
    vim.lsp.config("tinymist", {
-      on_attach = on_attach,
       capabilities = capabilities,
       settings = {
          formatterMode = "typstyle",

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/vscode-css-language-server.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/vscode-css-language-server.lua
@@ -1,11 +1,10 @@
 local M = {}
 
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    -- Enable completion using snippets
    capabilities.textDocument.completion.completionItem.snippetSupport = true
    vim.lsp.enable("cssls")
    vim.lsp.config("cssls", {
-      on_attach = on_attach,
       capabilities = capabilities,
       init_options = {
          provideFormatter = false, -- Let Prettier do the formatting

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/vscode-eslint-language-server.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/vscode-eslint-language-server.lua
@@ -1,9 +1,8 @@
 local M = {}
 
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    vim.lsp.enable("eslint")
    vim.lsp.config("eslint", {
-      on_attach = on_attach,
       capabilities = capabilities,
       settings = {
          -- The server can automatically fix problems by "formatting".

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/vscode-html-language-server.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/vscode-html-language-server.lua
@@ -1,11 +1,10 @@
 local M = {}
 
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    -- Enable completion using snippets
    capabilities.textDocument.completion.completionItem.snippetSupport = true
    vim.lsp.enable("html")
    vim.lsp.config("html", {
-      on_attach = on_attach,
       capabilities = capabilities,
       init_options = {
          provideFormatter = false, -- Let Prettier do the formatting

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/vscode-json-language-server.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/vscode-json-language-server.lua
@@ -1,11 +1,10 @@
 local M = {}
 
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    -- Enable completion using snippets
    capabilities.textDocument.completion.completionItem.snippetSupport = true
    vim.lsp.enable("jsonls")
    vim.lsp.config("jsonls", {
-      on_attach = on_attach,
       capabilities = capabilities,
       init_options = {
          provideFormatter = false, -- Let Prettier do the formatting

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/vtsls.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/vtsls.lua
@@ -1,10 +1,9 @@
 local M = {}
 
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    vim.lsp.enable({ "vtsls", "vue_ls" })
 
    vim.lsp.config("vue_ls", {
-      on_attach = on_attach,
       capabilities = capabilities,
    })
 
@@ -16,7 +15,6 @@ function M.setup(on_attach, capabilities)
    }
 
    vim.lsp.config("vtsls", {
-      on_attach = on_attach,
       capabilities = capabilities,
       settings = {
          vtsls = {

--- a/planet/home-manager/neovim/lua/plugins/lspconfig/zls.lua
+++ b/planet/home-manager/neovim/lua/plugins/lspconfig/zls.lua
@@ -1,9 +1,8 @@
 local M = {}
 
-function M.setup(on_attach, capabilities)
+function M.setup(capabilities)
    vim.lsp.enable("zls")
    vim.lsp.config("zls", {
-      on_attach = on_attach,
       capabilities = capabilities,
       settings = {
          zls = {


### PR DESCRIPTION
Configures Neovim to use `copilot-language-server` for LSP inline completions.